### PR TITLE
Require craftcms/cms ^3.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
       "bertoost\\placeholderurl\\": "src/"
     }
   },
+  "require": {
+    "craftcms/cms": "^3.0.0"
+  },
   "extra": {
     "name": "Placeholder URL",
     "handle": "placeholderurl",


### PR DESCRIPTION
As of yesterday the Plugin Store only shows plugins/plugin updates that it knows are compatible with the currently-installed version of Craft. It does that by checking the plugins’ `craftcms/cms` requirements. Which means plugins that don’t specify a `craftcms/cms` requirement will no longer be shown at all.

Once you accept this PR and cut a new release, your plugin will show up in the Plugin Store again. (Don’t forget to update the `version` property in `composer.json`.)